### PR TITLE
Move ExtractFrozenUpdate into lib/Update.py, and add an

### DIFF
--- a/lib/Exceptions.py
+++ b/lib/Exceptions.py
@@ -17,6 +17,11 @@ class ManifestInvalidSignature(Exception):
 class UpdateException(Exception):
     pass
 
+class UpdateBadFrozenFile(Exception):
+    """
+    Indicates a frozen update file was bad
+    """
+    pass
 
 class UpdateInsufficientSpace(UpdateException):
     """Raised when there is insufficient space to download


### PR DESCRIPTION
exception for it.  This should make it easier for the GUI
(or other clients) to extract an update.

Ticket # 29365