### PR TITLE
Default log level fix in FreenasOS

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -148,8 +148,9 @@ class SysLogHandler(logging.Handler):
             else:
                 _msg = msg[950 * i:950 * (i + 1)]
             syslog.syslog(
-                self.priority_names.get(record.levelname.lower(), "debug"),
-                _msg)
+                self.priority_names.get(record.levelname.lower(), syslog.LOG_DEBUG),
+                _msg
+            )
         syslog.closelog()
 
 


### PR DESCRIPTION
Default log level for freenasOS should be debug. This commit makes sure that happens and fixes the old issue where a string was used to set the default debug level which resulted in an exception.
Ticket: #38355