### PR TITLE
Don't fail when deleting a clone if it's got an invalid

### DIFF
--- a/lib/Update.py
+++ b/lib/Update.py
@@ -691,8 +691,11 @@ def UnmountClone(name, mount_point=None):
 def DeleteClone(name):
     # Delete the clone we created.
 
-    _CheckBEName(name)
-    
+    try:
+        _CheckBEName(name)
+    except InvalidBootEnvironmentNameException:
+        log.debug("Deleting BE with invalid name %s" % name)
+
     clone = FindClone(name)
     if clone is None:
         return False


### PR DESCRIPTION
name.  (Note that beadm itself may complain about the
name, but we'll at least try.)

Ticket #25057