### PR TITLE
tkt-55752 (master) add timestamp when freenas-verify completes

### DIFF
--- a/freenas-verify/freenas-verify.py
+++ b/freenas-verify/freenas-verify.py
@@ -2,9 +2,13 @@
 from __future__ import print_function
 import sys
 import traceback
+from datetime import dateime
+
 
 sys.path.append("/usr/local/lib")
 from freenasOS import Configuration
+
+datenow = datetime.now().strftime("%c")
 
 if __name__ == '__main__':
     try:
@@ -14,6 +18,7 @@ if __name__ == '__main__':
         sys.exit(74)
 
     if error_flag or warn_flag:
+        print("Verify completed at %s" (datenow))
         print("The following inconsistencies were found in your current install:")
 
         if ed['checksum']:
@@ -38,5 +43,6 @@ if __name__ == '__main__':
         sys.exit(1)
 
     else:
+        print("Verify completed at %s" (datenow))
         print("All Files, Directories and Symlinks in the system were verified successfully")
         sys.exit(0)


### PR DESCRIPTION
Wanting to move freenas-verify to a cron job and dump the results to a file instead of running every time a freenas-debug is generated. This greatly speeds up the freenas-debug process.

Redmine: https://redmine.ixsystems.com/issues/55752