### PR TITLE
Use the correct idiom for getting status code on http error.

### DIFF
--- a/lib/Configuration.py
+++ b/lib/Configuration.py
@@ -671,7 +671,7 @@ class Configuration(object):
                                        stream=True, headers=header_dict)
                     furl.raise_for_status()
                 except requests.exceptions.HTTPError as error:
-                    if error.status_code == HTTP_RANGE.value:
+                    if error.response.status_code == HTTP_RANGE.value:
                         # We've reached the end of the file already
                         # Can I get this incorrectly from any other server?
                         # Do I need to do something different for the progress handler?


### PR DESCRIPTION
The requests module has a different way to get the http status code; my testing never hit an error, apparently, until I tried it with a non-existent train.

(cherry picked from commit 11a2bb58dcb09ae0774554ba532d65ab7bb3b40c)